### PR TITLE
Fix project build settings for PESDK

### DIFF
--- a/ios/bizsoci.xcodeproj/project.pbxproj
+++ b/ios/bizsoci.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		8469844E223493D200BFECD9 /* PhotoEditorSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 846984122234770F00BFECD9 /* PhotoEditorSDK.framework */; };
 		8469844F223493D200BFECD9 /* PhotoEditorSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 846984122234770F00BFECD9 /* PhotoEditorSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
+		E9CE68BD223BC7440017BFC1 /* PESDKModule.m in Sources */ = {isa = PBXBuildFile; fileRef = E9CE68BB223BC7440017BFC1 /* PESDKModule.m */; };
+		E9CE68BE223BC7440017BFC1 /* LICENSE_IOS in Resources */ = {isa = PBXBuildFile; fileRef = E9CE68BC223BC7440017BFC1 /* LICENSE_IOS */; };
 		EC51B51438AC46FF80C7B02C /* libRNFS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F73E51F66B5C403084D9E4D3 /* libRNFS.a */; };
 		ED297163215061F000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED297162215061F000B7C4FE /* JavaScriptCore.framework */; };
 		ED2971652150620600B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2971642150620600B7C4FE /* JavaScriptCore.framework */; };
@@ -378,6 +380,9 @@
 		846984122234770F00BFECD9 /* PhotoEditorSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PhotoEditorSDK.framework; path = PhotoEditorSDK/PhotoEditorSDK.framework; sourceTree = "<group>"; };
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 		D11B8B856F1B4F5EB55E6362 /* RNFS.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFS.xcodeproj; path = "../node_modules/react-native-fs/RNFS.xcodeproj"; sourceTree = "<group>"; };
+		E9CE68BA223BC7440017BFC1 /* PESDKModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PESDKModule.h; sourceTree = "<group>"; };
+		E9CE68BB223BC7440017BFC1 /* PESDKModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PESDKModule.m; sourceTree = "<group>"; };
+		E9CE68BC223BC7440017BFC1 /* LICENSE_IOS */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE_IOS; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		F73E51F66B5C403084D9E4D3 /* libRNFS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNFS.a; sourceTree = "<group>"; };
@@ -523,6 +528,9 @@
 		13B07FAE1A68108700A75B9A /* bizsoci */ = {
 			isa = PBXGroup;
 			children = (
+				E9CE68BC223BC7440017BFC1 /* LICENSE_IOS */,
+				E9CE68BA223BC7440017BFC1 /* PESDKModule.h */,
+				E9CE68BB223BC7440017BFC1 /* PESDKModule.m */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -1131,6 +1139,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9CE68BE223BC7440017BFC1 /* LICENSE_IOS in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
 			);
@@ -1212,6 +1221,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				E9CE68BD223BC7440017BFC1 /* PESDKModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1318,6 +1328,7 @@
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
@@ -1346,6 +1357,7 @@
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";


### PR DESCRIPTION
Your sample project had the following issues:
- Always Embed Swift Standard Libraries for the `bizsoci` target was NOT set to true as documented here: https://docs.photoeditorsdk.com/guides/ios/v9/resources/faq
- You neither added the PESDKModule.h/m nor the IOS_LICENSE file to the iOS project, which essentially hides them from the running app.

Once I fixed the issues, the project builds and runs just fine. Only the 'Push PESDK Editor' button fails, as you altered the source to not pass an image. Our developer created a PR to fix the issues in your project.